### PR TITLE
Add basic assertions to enforce simple invariants

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,4 +58,5 @@ shadowJar {
 
 run {
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/foybot/instructions/DeleteInstruction.java
+++ b/src/main/java/foybot/instructions/DeleteInstruction.java
@@ -31,8 +31,10 @@ public class DeleteInstruction extends Instruction {
         } else if (index > tasks.size() - 1 || index < 0) {
             throw new FoyBotException("Index out of bounds.");
         } else {
+            int oldSize = tasks.size();
             Task deletedTask = tasks.get(index);
             tasks.delete(index);
+            assert tasks.size() == oldSize - 1 : "Task list size should decrease by 1 after delete";
             ui.showLine();
             ui.showMessage("Noted. I've removed this task:");
             ui.showMessage("    " + deletedTask.toString());

--- a/src/main/java/foybot/instructions/FindInstruction.java
+++ b/src/main/java/foybot/instructions/FindInstruction.java
@@ -29,6 +29,9 @@ public class FindInstruction extends Instruction {
     @Override
     public void execute(TaskList tasks, Ui ui) throws FoyBotException {
         ArrayList<Task> matches = tasks.findTasks(keyword);
+        assert matches.stream().allMatch(
+                t -> t.toString().toLowerCase().contains(keyword.toLowerCase()))
+                : "All find results should contain the search keyword";
 
         if (matches.isEmpty()) {
             ui.showMessage("No matching tasks found.");

--- a/src/main/java/foybot/tasks/EventTask.java
+++ b/src/main/java/foybot/tasks/EventTask.java
@@ -34,6 +34,7 @@ public class EventTask extends Task {
         if (fromTime.isAfter(toTime)) {
             throw new FoyBotException("Event start date must be before or equal to end date.");
         }
+        assert !fromTime.isAfter(toTime) : "Event start date should not be after end date";
     }
 
     public String getFromTo() {

--- a/src/main/java/foybot/tasks/Task.java
+++ b/src/main/java/foybot/tasks/Task.java
@@ -14,6 +14,7 @@ public abstract class Task {
      * @param description Description of the task.
      */
     public Task(String description) {
+        assert description != null : "Task description should not be null";
         this.description = description;
         this.isDone = false;
     }

--- a/src/main/java/foybot/tools/Storage.java
+++ b/src/main/java/foybot/tools/Storage.java
@@ -107,6 +107,7 @@ public class Storage {
 
         String type = parts[0];
         boolean isDone = parts[1].equals("1");
+        assert parts[1].equals("0") || parts[1].equals("1") : "Done flag should be 0 or 1";
         String rest = parts[2];
 
         Task task;
@@ -150,6 +151,7 @@ public class Storage {
      * @throws FoyBotException If the task cannot be represented.
      */
     private String taskToLine(Task task) throws FoyBotException {
+        assert task.getDescription() != null : "Task description should be non-null when saving";
         String doneFlag = task.isDone() ? "1" : "0";
 
         if (task instanceof TodoTask) {

--- a/src/main/java/foybot/tools/TaskList.java
+++ b/src/main/java/foybot/tools/TaskList.java
@@ -16,10 +16,13 @@ public class TaskList {
     }
 
     public TaskList(ArrayList<Task> tasks) {
+        // Constructor should never receive a null backing list.
+        assert tasks != null : "TaskList backing list should not be null";
         this.tasks = tasks;
     }
 
     public void addTask(Task task) {
+        assert task != null : "Task to add should not be null";
         tasks.add(task);
     }
 
@@ -45,6 +48,7 @@ public class TaskList {
      * @param keyword Keyword used to search for tasks.
      */
     public ArrayList<Task> findTasks(String keyword) {
+        assert keyword != null : "Find keyword should not be null";
         return tasks.stream()
                 .filter(t -> t.toString().toLowerCase().contains(keyword.toLowerCase()))
                 .collect(Collectors.toCollection(ArrayList::new));


### PR DESCRIPTION
## Summary
Introduced initial, basic assertions to document and enforce internal invariants (developer sanity checks).

## Changes
- Added `assert` checks in key spots to catch impossible/invalid internal states early (when assertions are enabled).
- Kept existing exception-based validation for runtime/user-facing robustness.

## Rationale
Assertions help surface internal programming errors earlier, rather than allowing them to manifest later as unexpected runtime exceptions.

## Testing
- [x] Existing tests pass

## Checklist
- [x] Code compiles
